### PR TITLE
Delete dropbox_ul.yml

### DIFF
--- a/dropbox_ul.yml
+++ b/dropbox_ul.yml
@@ -1,4 +1,0 @@
-dropbox_ul:
-    enabled: true
-    app_token: 'db app token'
-    path: '/dropbox-ul'


### PR DESCRIPTION
yml file no longer required for current v1.5.3 and above. yml contents are directly placed in config.toml file. Readme contains detailed instructions on how to make it work for toml.